### PR TITLE
Allow plugins to import modules from same directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # yapsy-sidecarless
-Override the Yapsy plugin manager to load Python modules as plugins without needing a yapsy-plugin sidecar file.
+Override the Yapsy plugin manager to load Python modules as plugins without needing a yapsy-plugin sidecar file.   Also temporarily updates the Python path when loading a plugin so that a given plugin can import modules from the same directory as the main plugin file.
 
 Yapsy plugin manager which loads plugin information from the containing Python
 module rather than a yapsy-plugin sidecar file.

--- a/plugins.py
+++ b/plugins.py
@@ -57,9 +57,13 @@ class Analyzer(_locators.IPluginFileAnalyzer):
         """
         import importlib.machinery
         import importlib.util
-
+        import os
+        import sys
         if filepath.endswith('.py'):
+            pre_load_path = list(sys.path)
             try:
+                temp_path, _ = os.path.split(filepath)
+                sys.path.append(temp_path)
                 loader = importlib.machinery.SourceFileLoader(
                     'testmod', filepath)
                 spec = importlib.util.spec_from_loader(loader.name, loader)
@@ -68,6 +72,9 @@ class Analyzer(_locators.IPluginFileAnalyzer):
                 return themodule
             except ImportError:
                 return None
+            finally:
+                sys.path = pre_load_path
+
         else:
             return None
 

--- a/test_data/nosidecar_with_import_plugin.py
+++ b/test_data/nosidecar_with_import_plugin.py
@@ -1,0 +1,18 @@
+""" Test plugin for one-file plugin manager, separate folder from package,
+    that imports another module from the plugin folder.
+"""
+
+from yapsy.IPlugin import IPlugin
+
+from nosidecar_with_import_plugin_other_class import OtherClass
+
+__plugin_name__ = 'Test plugin without sidecar file that imports module (remote)'
+__plugin_author__ = 'Kevin'
+
+
+class MyOtherPlugin(IPlugin):
+
+    def __init__(self):
+        super().__init__()
+        self.other_class = OtherClass()
+        print('Initialized no-sidecar plugin with import (remote).')

--- a/test_data/nosidecar_with_import_plugin_other_class.py
+++ b/test_data/nosidecar_with_import_plugin_other_class.py
@@ -1,0 +1,8 @@
+""" Class used by MyOtherPlugin to test import
+    of addtional modules when loading a plugin
+"""
+
+class OtherClass:
+
+    def __init__(self):
+        print("OtherClass.__init__")

--- a/test_plugins.py
+++ b/test_plugins.py
@@ -16,10 +16,10 @@ class BasicPluginTests(ut.TestCase):
         self.mngr.collectPlugins()
 
     def test_loaded_four(self):
-        """ Loaded exactly four plugins from local directory.
+        """ Loaded exactly five plugins from local directory.
         """
         N = len(self.mngr.getAllPlugins())
-        self.assertEqual(N, 4)
+        self.assertEqual(N, 5)
 
     def test_correct_names(self):
         """ Loaded plugin names are correct.
@@ -29,6 +29,7 @@ class BasicPluginTests(ut.TestCase):
             'Test plugin without sidecar file (local)',
             'Test plugin with sidecar file (remote)',
             'Test plugin without sidecar file (remote)',
+            'Test plugin without sidecar file that imports module (remote)'
         ]
         for p in self.mngr.getAllPlugins():
             self.assertIn(p.name, valid_names)


### PR DESCRIPTION
These changes allow a plugin to import files from the same directory as the main plugin file.   This allows the plugin to be distributed with any dependent modules.  

See _test_data/nosidecar_with_import_plugin.py_ as an example.

Unit tests updated and pass.